### PR TITLE
Message length boost fixes

### DIFF
--- a/sphinx/Scenes/Chat/Custom Views/Keyboard Accessory Views/ChatMessageTextFieldView+UITextViewDelegate.swift
+++ b/sphinx/Scenes/Chat/Custom Views/Keyboard Accessory Views/ChatMessageTextFieldView+UITextViewDelegate.swift
@@ -44,14 +44,10 @@ extension ChatMessageTextFieldView : UITextViewDelegate {
         let currentString = textView.text! as NSString
         let currentChangedString = currentString.replacingCharacters(in: range, with: text)
         
-        let effectiveThreadUUID = delegate?.getThreadUUID?()
-        let effectiveReplyUUID = delegate?.getReplyUUID?()
-        
-        return isMessageWithinByteLimit(
-            message: currentChangedString,
-            replyUUID: effectiveReplyUUID,
-            threadUUID: effectiveThreadUUID
-        )
+        return delegate?.isMessageLengthValid?(
+            text: currentChangedString,
+            sendingAttachment: mode == .Attachment
+        ) ?? true
     }
     
     func textViewDidChange(_ textView: UITextView) {
@@ -77,25 +73,6 @@ extension ChatMessageTextFieldView : UITextViewDelegate {
         audioButtonContainer.isHidden = forceSendButtonVisible
         
         attachmentButtonContainer.isHidden = (mode == .Attachment)
-    }
-    
-    func isMessageWithinByteLimit(
-        message: String,
-        replyUUID: String? = nil,
-        threadUUID: String? = nil,
-        byteLimit: Int = 869
-    ) -> Bool {
-        var totalMessage = message
-        
-        if let replyUUID = replyUUID {
-            totalMessage += replyUUID + "--------" //add padding to account for additional payload introduced by replyUUID
-        }
-        
-        if let threadUUID = threadUUID {
-            totalMessage += threadUUID + "-----------" //add padding to account for additional payload introduced by threadUUID
-        }
-        
-        return totalMessage.byteSize() <= byteLimit
     }
 }
 

--- a/sphinx/Scenes/Chat/Custom Views/Keyboard Accessory Views/ChatMessageTextFieldView.swift
+++ b/sphinx/Scenes/Chat/Custom Views/Keyboard Accessory Views/ChatMessageTextFieldView.swift
@@ -19,8 +19,7 @@ import UIKit
     @objc optional func shouldStartRecording()
     @objc optional func shouldStopAndSendAudio()
     @objc optional func shouldCancelRecording()
-    @objc optional func getThreadUUID() -> String?
-    @objc optional func getReplyUUID() -> String?
+    @objc optional func isMessageLengthValid(text: String, sendingAttachment: Bool) -> Bool
 }
 
 enum MessagesFieldMode: Int {
@@ -119,6 +118,7 @@ class ChatMessageTextFieldView: UIView {
                     title: "generic.error.title".localized,
                     message: "generic.message.error".localized
                 )
+                self.textView.text = text
             }
             self.sendButton.isUserInteractionEnabled = true
         })

--- a/sphinx/Scenes/Chat/Custom Views/New Chat VC/NewChatAccessoryView.swift
+++ b/sphinx/Scenes/Chat/Custom Views/New Chat VC/NewChatAccessoryView.swift
@@ -130,6 +130,8 @@ extension NewChatAccessoryView {
                 and: delegate
             )
         }
+        
+        messageFieldView.textView.becomeFirstResponder()
     }
     
     func resetReplyView() {

--- a/sphinx/Scenes/Chat/View Controllers/New Chat View Controller/New Chat View Controller/NewChatViewController+BottomViewDelegateExtension.swift
+++ b/sphinx/Scenes/Chat/View Controllers/New Chat View Controller/New Chat View Controller/NewChatViewController+BottomViewDelegateExtension.swift
@@ -67,12 +67,16 @@ extension NewChatViewController : ChatMessageTextFieldViewDelegate {
         chatViewModel.shouldCancelRecording()
     }
     
-    func getReplyUUID() -> String? {
-        return self.chatViewModel.replyingTo?.uuid
-    }
-    
-    func getThreadUUID() -> String? {
-        return self.threadUUID ?? self.chatViewModel.replyingTo?.replyUUID
+    func isMessageLengthValid(
+        text: String,
+        sendingAttachment: Bool
+    ) -> Bool {
+        return SphinxOnionManager.sharedInstance.isMessageLengthValid(
+            text: text,
+            sendingAttachment: sendingAttachment,
+            threadUUID: self.chatViewModel.replyingTo?.uuid,
+            replyUUID: self.threadUUID ?? self.chatViewModel.replyingTo?.replyUUID
+        )
     }
     
     func shouldStartGiphy(){


### PR DESCRIPTION
- Fix for boost failing and not being sent on tribes
- Setting focus on message field when replying
- Setting text again in message field if it fails