### PR TITLE
Fix no feedback for empty searches

### DIFF
--- a/sphinx/Scenes/Dashboard/DashboardRootViewController+PodcastFeedSearchResultsViewControllerDelegate.swift
+++ b/sphinx/Scenes/Dashboard/DashboardRootViewController+PodcastFeedSearchResultsViewControllerDelegate.swift
@@ -18,4 +18,10 @@ extension DashboardRootViewController: FeedSearchResultsViewControllerDelegate {
     func getPodcastSmallPlayerHeight() -> CGFloat{
         return podcastSmallPlayer.getViewHeight()
     }
+    
+    func showNoResults() {
+        self.feedSearchResultsContainerViewController.view.isHidden = true
+        self.feedsContainerViewController.showEmptyStateViewController()
+        self.feedsContainerViewController.emptyStateViewController.updateEmptyStateLabel()
+    }
 }

--- a/sphinx/Scenes/Dashboard/Feeds/Feed Content/Listen/DashboardFeedsEmptyStateViewController.swift
+++ b/sphinx/Scenes/Dashboard/Feeds/Feed Content/Listen/DashboardFeedsEmptyStateViewController.swift
@@ -41,13 +41,17 @@ extension DashboardFeedsEmptyStateViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        emptyStateMessageLabel.text = emptyStateMessageText
+        updateEmptyStateLabel()
     }
 
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
+        updateEmptyStateLabel()
+    }
+    
+    func updateEmptyStateLabel(){
         emptyStateMessageLabel.text = emptyStateMessageText
     }
 }

--- a/sphinx/Scenes/Dashboard/Feeds/Search/FeedSearchContainerViewController.swift
+++ b/sphinx/Scenes/Dashboard/Feeds/Search/FeedSearchContainerViewController.swift
@@ -21,6 +21,7 @@ protocol FeedSearchResultsViewControllerDelegate: AnyObject {
     func updateIsSearchingTorrents(isSearching:Bool)
     func getPodcastSmallPlayerHeight()->CGFloat
     func getBottomBarHeight()->CGFloat
+    func showNoResults()
 }
 
 
@@ -42,6 +43,10 @@ class FeedSearchContainerViewController: UIViewController, FeedSearchResultsColl
         
     func getFeedSource()->FeedSource{
         return self.resultsDelegate?.getFeedSource() ?? .RSS
+    }
+    
+    func showNoResults() {
+        self.resultsDelegate?.showNoResults()
     }
     
     lazy var fetchedResultsController: NSFetchedResultsController = Self
@@ -242,6 +247,8 @@ extension FeedSearchContainerViewController {
         
         searchResultsViewController.updateWithNew(searchResults: [])
         let finalType :FeedType = type ?? .BrowseTorrent
+        
+        self.view.superview?.isHidden = false
         searchTimer?.invalidate()
         searchTimer = Timer.scheduledTimer(timeInterval: 0.5, target: self, selector: #selector(fetchRemoteResults(timer:)), userInfo: ["search_query": searchQuery, "feed_type" : finalType, "feed_source": feedSource], repeats: false)
         

--- a/sphinx/Scenes/Dashboard/Feeds/Search/FeedSearchResultsCollectionViewController.swift
+++ b/sphinx/Scenes/Dashboard/Feeds/Search/FeedSearchResultsCollectionViewController.swift
@@ -10,6 +10,7 @@ import CoreData
 
 protocol FeedSearchResultsCollectionViewControllerDelegate : class {
     func getFeedSource()->FeedSource
+    func showNoResults()
 }
 
 class FeedSearchResultsCollectionViewController: UICollectionViewController {
@@ -343,6 +344,13 @@ extension FeedSearchResultsCollectionViewController {
         if let _ = dataSource {
             updateSnapshot(shouldAnimate: shouldAnimate)
         }
+        
+        if (self.feedSearchResults.count + self.subscribedFeeds.count) == 0{
+            showNoResultsLabel()
+        }
+        else{
+            self.view.superview?.isHidden = false
+        }
     }
     
 
@@ -355,6 +363,17 @@ extension FeedSearchResultsCollectionViewController {
         if let _ = dataSource {
             updateSnapshot(shouldAnimate: shouldAnimate)
         }
+        
+        if (self.feedSearchResults.count + self.subscribedFeeds.count) == 0{
+            showNoResultsLabel()
+        }
+        else{
+            self.view.superview?.isHidden = false
+        }
+    }
+    
+    func showNoResultsLabel(){
+        self.delegate?.showNoResults()
     }
 }
 


### PR DESCRIPTION
- simple approach to circumvent failed callback