### PR TITLE
Allow landscape mode on Media Full Screen view

### DIFF
--- a/sphinx/AppDelegate.swift
+++ b/sphinx/AppDelegate.swift
@@ -49,11 +49,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         case AppStore
     }
 
+    static var orientationLock = UIInterfaceOrientationMask.portrait
+
     //Lifecycle events
     func application(
         _ application: UIApplication,
         supportedInterfaceOrientationsFor window: UIWindow?
     ) -> UIInterfaceOrientationMask {
+        if AppDelegate.orientationLock != .portrait {
+            return AppDelegate.orientationLock
+        }
         
         if UIDevice.current.isIpad {
             return .allButUpsideDown

--- a/sphinx/Scenes/Chat/View Controllers/Chat Attachment/AttachmentFullScreenViewController.swift
+++ b/sphinx/Scenes/Chat/View Controllers/Chat Attachment/AttachmentFullScreenViewController.swift
@@ -59,6 +59,26 @@ class AttachmentFullScreenViewController: UIViewController, CanRotate {
         }
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        AppDelegate.orientationLock = .all
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        AppDelegate.orientationLock = .portrait
+    }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .all
+    }
+    
+    override var shouldAutorotate: Bool {
+        return true
+    }
+    
     func showWebViewImage() {
         guard let imageUrl = imageUrl else{
             return
@@ -162,6 +182,7 @@ class AttachmentFullScreenViewController: UIViewController, CanRotate {
         
         if !UIDevice.current.isIpad {
             UIDevice.current.setValue(Int(UIInterfaceOrientation.portrait.rawValue), forKey: "orientation")
+            AppDelegate.orientationLock = .portrait
         }
         
         self.dismiss(animated: animated, completion: {


### PR DESCRIPTION
## Summary
This PR enables landscape mode in the **Media Full-Screen View** by updating orientation handling in `AppDelegate` and `AttachmentFullScreenViewController`.

## Changes Implemented
- Added a static variable in `AppDelegate` to manage orientation locking.
- Updated `supportedInterfaceOrientationsFor` in `AppDelegate` to respect the orientation lock.
- Modified `viewWillAppear` and `viewWillDisappear` in `AttachmentFullScreenViewController` to adjust the orientation dynamically.
- Allowed all interface orientations and enabled autorotation in `AttachmentFullScreenViewController`.


