### PR TITLE
Show Episode information in Recently Played section on Feed - All tab

### DIFF
--- a/sphinx/Core Data/Content Feed/ContentFeed+Computeds.swift
+++ b/sphinx/Core Data/Content Feed/ContentFeed+Computeds.swift
@@ -68,4 +68,50 @@ extension ContentFeed {
         
         return sortedItemsArray
     }
+    
+    var currentItemId: String {
+        get {
+            return UserDefaults.standard.string(forKey: "current-item-id-\(feedID)") ?? ""
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "current-item-id-\(feedID)")
+        }
+    }
+    
+    var currentItem: ContentFeedItem? {
+        if !itemsArray.isEmpty {
+            // First try to get the current playing item
+            let currentId = currentItemId
+            if !currentId.isEmpty,
+               let currentItem = itemsArray.first(where: { $0.id == currentId }) {
+                return currentItem
+            }
+            // Then try the last consumed item
+            if let lastConsumedId = lastConsumedItemId,
+               let lastConsumedItem = itemsArray.first(where: { $0.id == lastConsumedId }) {
+                return lastConsumedItem
+            }
+            // Finally fall back to most recent item
+            return itemsArray.first
+        }
+        return nil
+    }
+    
+    var lastConsumedItemId: String? {
+        get {
+            return UserDefaults.standard.string(forKey: "last-consumed-item-id-\(feedID)")
+        }
+        set {
+            if let newValue = newValue {
+                UserDefaults.standard.set(newValue, forKey: "last-consumed-item-id-\(feedID)")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "last-consumed-item-id-\(feedID)")
+            }
+        }
+    }
+    
+    func updateLastPlayedItem(_ item: ContentFeedItem) {
+        lastConsumedItemId = item.id
+        dateLastConsumed = Date()
+    }
 }

--- a/sphinx/Scenes/Dashboard/Feeds/Feed Content/Collection View Cells/DashboardFeedSquaredThumbnailCollectionViewCell.swift
+++ b/sphinx/Scenes/Dashboard/Feeds/Feed Content/Collection View Cells/DashboardFeedSquaredThumbnailCollectionViewCell.swift
@@ -52,6 +52,24 @@ extension DashboardFeedSquaredThumbnailCollectionViewCell {
     var placeholderImage: UIImage? {
         UIImage(named: item.placeholderImageName ?? "podcastPlaceholder")
     }
+
+    func configure(withRecentItem item: ContentFeedItem, feed: ContentFeed) {
+        titleLabel.text = item.title
+        subtitleLabel.text = feed.title
+        
+        if let imageURL = item.imageURL ?? feed.imageURL {
+            thumbnailImageView.sd_setImage(
+                with: imageURL,
+                placeholderImage: UIImage(named: "podcast-placeholder"),
+                options: [.highPriority],
+                progress: nil
+            )
+        } else {
+            thumbnailImageView.image = UIImage(named: "podcast-placeholder")
+        }
+        
+        dateLabel.text = item.datePublished?.publishDateString ?? "Date unavailable"
+    }
 }
     
 


### PR DESCRIPTION
## Summary  
This PR improves how recent content items (podcasts, videos, newsletters) are handled and displayed in the `AllTribeFeedsCollectionViewController`. Key enhancements include:  

### 🔹 Recent Item Tracking  
- Introduces `recentPodcastItem`, `recentVideoItem`, and `recentNewsletterItem` cases in `DataSourceItem` to differentiate content types.  
- Adds `recentItemEntity` to easily extract recent item information from a feed.  

### 🔹 UserDefaults Enhancements  
- Implements `currentItemId` and `lastConsumedItemId` stored in `UserDefaults` for better state persistence.  
- Improves `currentItem` retrieval by prioritizing the last played item before falling back to the most recent item.  

### 🔹 UI & Data Source Improvements  
- Updates how recently played items are fetched, sorted by `dateLastConsumed`, and displayed in the dashboard.  
- Refactors `configure(withRecentItem:)` in `DashboardFeedSquaredThumbnailCollectionViewCell` to handle recent item display with proper image loading and metadata.  
- Ensures `onCellSelected` correctly identifies and navigates to the selected recent content item.  