### PR TITLE
Timezone sharing ability - Database model changes 

### DIFF
--- a/sphinx.xcodeproj/project.pbxproj
+++ b/sphinx.xcodeproj/project.pbxproj
@@ -1891,6 +1891,7 @@
 		47FDDB1B2562D77100BBF15F /* boost_animation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = boost_animation.json; sourceTree = "<group>"; };
 		47FE9A3D23C381A20090913F /* UITapGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITapGestureRecognizer.swift; sourceTree = "<group>"; };
 		487E10CEB3D07B0840A84681 /* Pods_sphinx.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_sphinx.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7734ED4D2D66C733003276BA /* sphinx 53.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "sphinx 53.xcdatamodel"; sourceTree = "<group>"; };
 		9386C2882BB25C2200ABDEF3 /* AddTagsButtonCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddTagsButtonCell.xib; sourceTree = "<group>"; };
 		9386C28A2BB25EDC00ABDEF3 /* AddedTagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddedTagsView.swift; sourceTree = "<group>"; };
 		9386C28C2BB25F2700ABDEF3 /* AddedTagsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddedTagsView.xib; sourceTree = "<group>"; };
@@ -6872,7 +6873,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 168;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 8297M44YTW;
+        DEVELOPMENT_TEAM = 8297M44YTW;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = sphinx/Info.plist;
@@ -6962,7 +6963,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = sphinx/sphinx.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 168;
+				CURRENT_PROJECT_VERSION = 169;
 				DEVELOPMENT_TEAM = 8297M44YTW;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -7292,6 +7293,7 @@
 		47F35D4A2373156A0042A58F /* sphinx.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				7734ED4D2D66C733003276BA /* sphinx 53.xcdatamodel */,
 				473873B02CD92C1300CBBC28 /* sphinx 52.xcdatamodel */,
 				CE9D766E2C73D569008CEEA0 /* sphinx 51.xcdatamodel */,
 				472A4E1B2C4EB5C400B10934 /* sphinx 50.xcdatamodel */,
@@ -7345,7 +7347,7 @@
 				475E4162238588A200928931 /* sphinx 2.xcdatamodel */,
 				47F35D4B2373156A0042A58F /* sphinx.xcdatamodel */,
 			);
-			currentVersion = 473873B02CD92C1300CBBC28 /* sphinx 52.xcdatamodel */;
+			currentVersion = 7734ED4D2D66C733003276BA /* sphinx 53.xcdatamodel */;
 			path = sphinx.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/sphinx/Core Data/Chat/Chat+CoreDataProperties.swift
+++ b/sphinx/Core Data/Chat/Chat+CoreDataProperties.swift
@@ -49,6 +49,10 @@ extension Chat {
     @NSManaged public var cachedMediaSet: NSSet?
     @NSManaged public var subscription: Subscription?
     @NSManaged public var lastMessage: TransactionMessage?
+    @NSManaged public var timezoneEnabled: Bool
+    @NSManaged public var timezoneIdentifier: String?
+    @NSManaged public var remoteTimezoneIdentifier: String?
+    @NSManaged public var timezoneUpdated: Bool
 }
 
 

--- a/sphinx/Core Data/TransactionMessage/TransactionMessage+CoreDataProperties.swift
+++ b/sphinx/Core Data/TransactionMessage/TransactionMessage+CoreDataProperties.swift
@@ -52,4 +52,5 @@ extension TransactionMessage {
     @NSManaged public var mediaFileSize: Int
     @NSManaged public var muid: String?
     @NSManaged public var threadUUID: String?
+    @NSManaged public var remoteTimezoneIdentifier: String?
 }

--- a/sphinx/Core Data/sphinx.xcdatamodeld/.xccurrentversion
+++ b/sphinx/Core Data/sphinx.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>sphinx 52.xcdatamodel</string>
+	<string>sphinx 53.xcdatamodel</string>
 </dict>
 </plist>

--- a/sphinx/Core Data/sphinx.xcdatamodeld/sphinx 53.xcdatamodel/contents
+++ b/sphinx/Core Data/sphinx.xcdatamodeld/sphinx 53.xcdatamodel/contents
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="23H222" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="ActionTrack" representedClassName="ActionTrack" syncable="YES">
+        <attribute name="metaData" attributeType="String" defaultValueString=""/>
+        <attribute name="type" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="uploaded" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="CachedMedia" representedClassName="CachedMedia" syncable="YES">
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="fileExtension" optional="YES" attributeType="String"/>
+        <attribute name="fileName" optional="YES" attributeType="String"/>
+        <attribute name="filePath" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="key" optional="YES" attributeType="String"/>
+        <relationship name="chat" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Chat" inverseName="cachedMediaSet" inverseEntity="Chat"/>
+    </entity>
+    <entity name="Chat" representedClassName="Chat" syncable="YES">
+        <attribute name="contactIds" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="escrowAmount" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="groupKey" optional="YES" attributeType="String"/>
+        <attribute name="host" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isTribeICreated" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="muted" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="myAlias" optional="YES" attributeType="String"/>
+        <attribute name="myPhotoUrl" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="notify" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ownerPubkey" optional="YES" attributeType="String"/>
+        <attribute name="pendingContactIds" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
+        <attribute name="photoUrl" optional="YES" attributeType="String"/>
+        <attribute name="pin" optional="YES" attributeType="String"/>
+        <attribute name="pinnedMessageUUID" optional="YES" attributeType="String"/>
+        <attribute name="pricePerMessage" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="priceToJoin" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="privateTribe" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="remoteTimezoneIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="secondBrainUrl" optional="YES" attributeType="String"/>
+        <attribute name="seen" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="status" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timezoneEnabled" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="timezoneIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="timezoneUpdated" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="type" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="unlisted" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+        <attribute name="webAppLastDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="cachedMediaSet" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CachedMedia" inverseName="chat" inverseEntity="CachedMedia"/>
+        <relationship name="contentFeed" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ContentFeed" inverseName="chat" inverseEntity="ContentFeed"/>
+        <relationship name="lastMessage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TransactionMessage"/>
+        <relationship name="messages" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TransactionMessage" inverseName="chat" inverseEntity="TransactionMessage"/>
+        <relationship name="subscription" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Subscription" inverseName="chat" inverseEntity="Subscription"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+                <constraint value="ownerPubkey"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="ContentFeed" representedClassName="ContentFeed" syncable="YES">
+        <attribute name="authorName" optional="YES" attributeType="String"/>
+        <attribute name="dateLastConsumed" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="datePublished" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="feedDescription" optional="YES" attributeType="String"/>
+        <attribute name="feedID" attributeType="String"/>
+        <attribute name="feedKindValue" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="feedURL" optional="YES" attributeType="URI"/>
+        <attribute name="generator" optional="YES" attributeType="String"/>
+        <attribute name="imageURL" optional="YES" attributeType="URI"/>
+        <attribute name="isSubscribedToFromSearch" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="language" optional="YES" attributeType="String"/>
+        <attribute name="lastDownloadedEpisodeId" optional="YES" attributeType="String"/>
+        <attribute name="linkURL" optional="YES" attributeType="URI"/>
+        <attribute name="mediaKindValue" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ownerURL" optional="YES" attributeType="URI"/>
+        <attribute name="title" attributeType="String"/>
+        <relationship name="chat" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Chat" inverseName="contentFeed" inverseEntity="Chat"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ContentFeedItem" inverseName="contentFeed" inverseEntity="ContentFeedItem"/>
+        <relationship name="paymentDestinations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ContentFeedPaymentDestination" inverseName="feed" inverseEntity="ContentFeedPaymentDestination"/>
+        <relationship name="paymentModel" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ContentFeedPaymentModel" inverseName="feed" inverseEntity="ContentFeedPaymentModel"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="feedID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="ContentFeedItem" representedClassName="ContentFeedItem" syncable="YES">
+        <attribute name="authorName" optional="YES" attributeType="String"/>
+        <attribute name="datePublished" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="enclosureKind" optional="YES" attributeType="String"/>
+        <attribute name="enclosureURL" optional="YES" attributeType="URI"/>
+        <attribute name="feedKindValue" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="imageURL" optional="YES" attributeType="URI"/>
+        <attribute name="itemDescription" optional="YES" attributeType="String"/>
+        <attribute name="itemID" attributeType="String"/>
+        <attribute name="linkURL" optional="YES" attributeType="URI"/>
+        <attribute name="mediaKindValue" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String"/>
+        <relationship name="contentFeed" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ContentFeed" inverseName="items" inverseEntity="ContentFeed"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="itemID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="ContentFeedPaymentDestination" representedClassName="ContentFeedPaymentDestination" syncable="YES">
+        <attribute name="address" optional="YES" attributeType="String"/>
+        <attribute name="customKey" optional="YES" attributeType="String"/>
+        <attribute name="customValue" optional="YES" attributeType="String"/>
+        <attribute name="split" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <relationship name="feed" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ContentFeed" inverseName="paymentDestinations" inverseEntity="ContentFeed"/>
+    </entity>
+    <entity name="ContentFeedPaymentModel" representedClassName="ContentFeedPaymentModel" syncable="YES">
+        <attribute name="suggestedBTC" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <relationship name="feed" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ContentFeed" inverseName="paymentModel" inverseEntity="ContentFeed"/>
+    </entity>
+    <entity name="LSat" representedClassName="LSat" syncable="YES">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="issuer" optional="YES" attributeType="String"/>
+        <attribute name="macaroon" attributeType="String"/>
+        <attribute name="metadata" optional="YES" attributeType="String"/>
+        <attribute name="paths" optional="YES" attributeType="String"/>
+        <attribute name="paymentRequest" attributeType="String"/>
+        <attribute name="preimage" optional="YES" attributeType="String"/>
+        <attribute name="status" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="NotificationData" representedClassName="NotificationData" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="userInfo" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName"/>
+    </entity>
+    <entity name="Server" representedClassName="Server" syncable="YES">
+        <attribute name="ip" optional="YES" attributeType="String"/>
+        <attribute name="pubKey" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="Subscription" representedClassName="Subscription" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="count" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="cron" optional="YES" attributeType="String"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="ended" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="endNumber" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="paused" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="chat" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Chat" inverseName="subscription" inverseEntity="Chat"/>
+        <relationship name="contact" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserContact" inverseName="subscriptions" inverseEntity="UserContact"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="TransactionMessage" representedClassName="TransactionMessage" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="amountMsat" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="encrypted" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="errorMessage" optional="YES" attributeType="String"/>
+        <attribute name="expirationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="invoice" optional="YES" attributeType="String"/>
+        <attribute name="mediaFileName" optional="YES" attributeType="String"/>
+        <attribute name="mediaFileSize" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="mediaKey" optional="YES" attributeType="String"/>
+        <attribute name="mediaToken" optional="YES" attributeType="String"/>
+        <attribute name="mediaType" optional="YES" attributeType="String"/>
+        <attribute name="messageContent" optional="YES" attributeType="String"/>
+        <attribute name="muid" optional="YES" attributeType="String"/>
+        <attribute name="originalMuid" optional="YES" attributeType="String"/>
+        <attribute name="paymentHash" optional="YES" attributeType="String"/>
+        <attribute name="person" optional="YES" attributeType="String"/>
+        <attribute name="push" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="receiverId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="recipientAlias" optional="YES" attributeType="String"/>
+        <attribute name="recipientPic" optional="YES" attributeType="String"/>
+        <attribute name="remoteTimezoneIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="replyUUID" optional="YES" attributeType="String"/>
+        <attribute name="seen" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="senderAlias" optional="YES" attributeType="String"/>
+        <attribute name="senderId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="senderPic" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="tag" optional="YES" attributeType="String"/>
+        <attribute name="threadUUID" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+        <relationship name="chat" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Chat" inverseName="messages" inverseEntity="Chat"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="UserContact" representedClassName="UserContact" syncable="YES">
+        <attribute name="avatarUrl" optional="YES" attributeType="String"/>
+        <attribute name="blocked" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="contactKey" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="email" optional="YES" attributeType="String"/>
+        <attribute name="fromGroup" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="index" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isOwner" optional="YES" attributeType="Boolean" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="newMessages" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="nickname" optional="YES" attributeType="String"/>
+        <attribute name="nodeAlias" optional="YES" attributeType="String"/>
+        <attribute name="notificationSound" optional="YES" attributeType="String"/>
+        <attribute name="phoneNumber" optional="YES" attributeType="String"/>
+        <attribute name="pin" optional="YES" attributeType="String"/>
+        <attribute name="privatePhoto" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="publicKey" optional="YES" attributeType="String"/>
+        <attribute name="routeHint" optional="YES" attributeType="String"/>
+        <attribute name="scid" optional="YES" attributeType="String"/>
+        <attribute name="sentInviteCode" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="timeZone" optional="YES" attributeType="String"/>
+        <attribute name="tipAmount" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <relationship name="invite" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="UserInvite" inverseName="contact" inverseEntity="UserInvite"/>
+        <relationship name="subscriptions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Subscription" inverseName="contact" inverseEntity="Subscription"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="UserInvite" representedClassName="UserInvite" syncable="YES">
+        <attribute name="inviteString" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="status" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="welcomeMessage" optional="YES" attributeType="String"/>
+        <relationship name="contact" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserContact" inverseName="invite" inverseEntity="UserContact"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="inviteString"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+</model>


### PR DESCRIPTION
This PR adds new timezone attributes and enables migration for the Core Data model.

### Changes Made
- **New Model Version:** Created a new Core Data model version (53).
- **Chat Entity Updates:**  
  - Added attributes:
    - `timezoneEnabled` (Bool, default: true)
    - `timezoneIdentifier` (String, default: null)
    - `remoteTimezoneIdentifier` (String, default: null)
    - `timezoneUpdated` (Bool, default: true)
- **TransactionMessage Entity Updates:**  
  - Added attribute:
    - `remoteTimezoneIdentifier` (String, default: nil)
- **NSManagedObject Subclasses:** Updated `Chat+CoreDataProperties.swift` and `TransactionMessage+CoreDataProperties.swift` accordingly.

### Verification
- Built the app on the **develop** branch.
- Ran the new feature version over the existing data store with no issues or crashes.