### PR TITLE
Sending and receiving timezone logic implementation

### DIFF
--- a/sphinx/Crypter/SphinxOnionManager+StructsAndHelpersExtension.swift
+++ b/sphinx/Crypter/SphinxOnionManager+StructsAndHelpersExtension.swift
@@ -112,6 +112,7 @@ struct MessageInnerContent: Mappable {
     var amount: Int? = nil
     var fullContactInfo: String? = nil
     var recipientAlias: String? = nil
+    var metadata: String? = nil
 
     init?(map: Map) {}
     
@@ -130,6 +131,7 @@ struct MessageInnerContent: Mappable {
         amount          <- map["amount"]
         fullContactInfo <- map["fullContactInfo"]
         recipientAlias  <- map["recipientAlias"]
+        metadata        <- map["metadata"]
     }
     
     func getRouteHint() -> String? {
@@ -161,6 +163,8 @@ struct GenericIncomingMessage: Mappable {
     var fullContactInfo: String? = nil
     var photoUrl: String? = nil
     var tag: String? = nil
+    var timezone: String? = nil
+    
 
     init?(map: Map) {}
     
@@ -206,6 +210,17 @@ struct GenericIncomingMessage: Mappable {
             } else {
                 self.timestamp = innerContent.date
             }
+            
+            if let metadataString = innerContent.metadata,
+               let metadataData = metadataString.data(using: .utf8) {
+                do {
+                    if let metadataDict = try JSONSerialization.jsonObject(with: metadataData, options: []) as? [String: Any] {
+                        self.timezone = metadataDict["timezone"] as? String
+                    }
+                } catch {
+                    print("Error parsing metadata JSON: \(error)")
+                }
+            }
         }
         
         if let paymentHash = msg.paymentHash {
@@ -240,7 +255,7 @@ struct GenericIncomingMessage: Mappable {
         mediaType  <- map["mediaType"]
         mediaKey   <- map["mediaKey"]
         muid       <- map["muid"]
-        
+        timezone   <- map["timezone"]
     }
 }
 

--- a/sphinx/Scenes/Chat/View Controllers/New Chat View Controller/Custom Views/TimezoneSharingView.swift
+++ b/sphinx/Scenes/Chat/View Controllers/New Chat View Controller/Custom Views/TimezoneSharingView.swift
@@ -10,6 +10,7 @@ import UIKit
 
 protocol TimezoneSharingViewDelegate: class {
     func shouldPresentPickerViewWith(delegate: PickerViewDelegate)
+    func timezoneSharingSettingsChanged(enabled: Bool, identifier: String?)
 }
 
 class TimezoneSharingView: UIView {
@@ -40,6 +41,33 @@ class TimezoneSharingView: UIView {
         
         shareTimezoneSwitch.onTintColor = UIColor.Sphinx.PrimaryBlue
         timezoneField.text = TimezoneSharingView.kDefaultValue
+        
+        shareTimezoneSwitch.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
+    }
+    
+    @objc func switchValueChanged() {
+        notifyDelegate()
+    }
+    
+    func configure(enabled: Bool, identifier: String?) {
+        shareTimezoneSwitch.isOn = enabled
+        timezoneField.text = identifier ?? TimezoneSharingView.kDefaultValue
+    }
+    
+    func getTimezoneIdentifier() -> String? {
+        let value = timezoneField.text ?? TimezoneSharingView.kDefaultValue
+        return value == TimezoneSharingView.kDefaultValue ? nil : value
+    }
+    
+    func isTimezoneEnabled() -> Bool {
+        return shareTimezoneSwitch.isOn
+    }
+    
+    private func notifyDelegate() {
+        delegate?.timezoneSharingSettingsChanged(
+            enabled: isTimezoneEnabled(),
+            identifier: getTimezoneIdentifier()
+        )
     }
     
     @IBAction func timezoneButtonTouched() {
@@ -50,5 +78,6 @@ class TimezoneSharingView: UIView {
 extension TimezoneSharingView : PickerViewDelegate {
     func didSelectValue(value: String) {
         timezoneField.text = value
+        notifyDelegate()
     }
 }


### PR DESCRIPTION
This PR adds logic to send and store timezone information in chat messages. A new metadata field is introduced in MessageInnerContent to handle additional JSON data. Users can enable or disable timezone sharing via a new toggle and select their timezone, which is displayed in the UI and stored in the chat settings.

## Key Changes:
**Models:** Added metadata field in MessageInnerContent to store timezone data.
**UI Updates:** Added a toggle to enable/disable timezone sharing (timezoneEnabled).
Added a field to display and modify timezoneIdentifier (shows "Use Computer Settings" if NULL).
**Timezone Handling Logic:**
Store timezoneEnabled and timezoneIdentifier when updated.
Mark timezoneUpdated as true when the timezone is changed.
**Sending Timezone:**
Timezone data is added to metadata in formatMsg() when timezoneEnabled and timezoneUpdated are true.
timezoneUpdated is reset to false after the message is sent to prevent redundant updates.
**Receiving Timezone:**
Extract timezone from metadata in incoming messages.
Store remoteTimezoneIdentifier in chat for direct messages and in message for tribe messages.