### PR TITLE
Timezone sharing ability - Show remote timezone information on chat header and messages

### DIFF
--- a/sphinx/Crypter/SphinxOnionManager+ChatExtension.swift
+++ b/sphinx/Crypter/SphinxOnionManager+ChatExtension.swift
@@ -133,7 +133,7 @@ extension SphinxOnionManager {
                 let timezoneMetadata = ["timezone": timezoneIdentifier]
                 if let metadataJSON = try? JSONSerialization.data(withJSONObject: timezoneMetadata),
                    let metadataString = String(data: metadataJSON, encoding: .utf8) {
-                    msg["metadata"] = metadataString)
+                    msg["metadata"] = metadataString
                 }
             }
             
@@ -141,6 +141,7 @@ extension SphinxOnionManager {
             chat.timezoneUpdated = false
             chat.managedObjectContext?.saveContext()
         }
+
         
         switch TransactionMessage.TransactionMessageType(rawValue: Int(type)) {
         case .message, .boost, .delete, .call, .groupLeave, .memberReject, .memberApprove,.groupDelete:

--- a/sphinx/Scenes/Chat/Custom Views/Chat/ChatHeaderView.swift
+++ b/sphinx/Scenes/Chat/Custom Views/Chat/ChatHeaderView.swift
@@ -49,6 +49,7 @@ class ChatHeaderView: UIView {
     @IBOutlet weak var pendingChatDashedOutline: UIView!
     @IBOutlet weak var imageContainerWidth: NSLayoutConstraint!
     @IBOutlet weak var imageWidthConstraint: NSLayoutConstraint!
+    @IBOutlet weak var remoteTimezoneIdentifier: UILabel!
     
     var chat: Chat? = nil
     var contact: UserContact? = nil
@@ -99,6 +100,7 @@ class ChatHeaderView: UIView {
         let isEncrypted = (contact?.status == UserContact.Status.Confirmed.rawValue) || (chat?.status == Chat.ChatStatus.approved.rawValue)
         lockSign.text = isEncrypted ? "lock" : "lock_open"
         lockSign.isHidden = !isEncrypted
+        remoteTimezoneIdentifier.text = chat?.remoteTimezoneIdentifier?.replacingOccurrences(of: "_", with: " ")
         
         configureWebAppButton()
         configureThreadsButton()

--- a/sphinx/Scenes/Chat/Custom Views/Chat/ChatHeaderView.xib
+++ b/sphinx/Scenes/Chat/Custom Views/Chat/ChatHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -37,6 +37,7 @@
                 <outlet property="optionsButton" destination="ahL-K7-tna" id="Xmm-DE-V0F"/>
                 <outlet property="pendingChatDashedOutline" destination="uRG-Ma-Jgw" id="Jun-DW-S1d"/>
                 <outlet property="profileImageView" destination="FzU-vr-ru9" id="VV3-FJ-SPa"/>
+                <outlet property="remoteTimezoneIdentifier" destination="OSQ-S1-xVE" id="0TP-zC-g23"/>
                 <outlet property="scheduleIcon" destination="nTq-5D-5Hn" id="y0L-dW-BuH"/>
                 <outlet property="secondBrainButton" destination="U14-c4-K83" id="ITi-OI-a1g"/>
                 <outlet property="showThreadsButton" destination="6uG-XH-Ptg" id="RkN-o4-DJl"/>
@@ -261,6 +262,13 @@
                             </subviews>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </stackView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Continent/Country/City" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="OSQ-S1-xVE">
+                            <rect key="frame" x="102" y="44" width="292" height="13"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="11"/>
+                            <color key="textColor" name="SecondaryText"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>

--- a/sphinx/Scenes/Chat/Table View Cells/Chat/NewMessageTableViewCell/Custom Views/Bubble Row views/StatusHeaderView.swift
+++ b/sphinx/Scenes/Chat/Table View Cells/Chat/NewMessageTableViewCell/Custom Views/Bubble Row views/StatusHeaderView.swift
@@ -35,6 +35,9 @@ class StatusHeaderView: UIView {
     
     @IBOutlet weak var expiredInvoiceReceivedHeader: UIStackView!
     @IBOutlet weak var expiredInvoiceReceivedLabel: UILabel!
+    @IBOutlet weak var remoteTimezoneIdentifier: UILabel!
+
+    
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -91,6 +94,13 @@ class StatusHeaderView: UIView {
         expiredInvoiceSentHeader.isHidden = !statusHeader.showExpiredSent
         expiredInvoiceReceivedHeader.isHidden = !statusHeader.showExpiredReceived
         configureWith(expirationTimestamp: statusHeader.expirationTimestamp)
+
+        if let identifier = statusHeader.remoteTimezoneIdentifier?.replacingOccurrences(of: "_", with: " "), !identifier.isEmpty {
+            remoteTimezoneIdentifier.isHidden = false
+            remoteTimezoneIdentifier.text = identifier
+        } else {
+            remoteTimezoneIdentifier.isHidden = true
+        }
         
         let thirtySecondsAgo = Date().addingTimeInterval(-30)
         let isScheduleVisible = statusHeader.showScheduleIcon && statusHeader.messageDate < thirtySecondsAgo

--- a/sphinx/Scenes/Chat/Table View Cells/Chat/NewMessageTableViewCell/Custom Views/Bubble Row views/StatusHeaderView.xib
+++ b/sphinx/Scenes/Chat/Table View Cells/Chat/NewMessageTableViewCell/Custom Views/Bubble Row views/StatusHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -33,6 +33,7 @@
                 <outlet property="receivedLockIcon" destination="raA-FE-Oun" id="lHR-Si-lBZ"/>
                 <outlet property="receivedSenderLabel" destination="a1n-vE-EGm" id="EXz-zw-X2C"/>
                 <outlet property="receivedStatusHeader" destination="doW-39-j69" id="Kvp-MX-YxC"/>
+                <outlet property="remoteTimezoneIdentifier" destination="jGL-Xr-Bif" id="czC-8V-J8z"/>
                 <outlet property="sentDateLabel" destination="Izc-1S-aLu" id="YrD-XY-4pA"/>
                 <outlet property="sentErrorIcon" destination="DRW-Za-E1A" id="Nzd-89-9ma"/>
                 <outlet property="sentErrorMessage" destination="jBP-CU-thj" id="0nY-9i-UIy"/>
@@ -107,15 +108,21 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Monday 6:05 AM" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lEb-TB-XrY">
-                            <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="17"/>
+                            <rect key="frame" x="0.0" y="0.0" width="0.0" height="17"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="10"/>
                             <color key="textColor" name="SecondaryText"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="lock" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="raA-FE-Oun">
-                            <rect key="frame" x="79.666666666666671" y="0.0" width="13" height="17"/>
+                            <rect key="frame" x="4" y="0.0" width="0.0" height="17"/>
                             <fontDescription key="fontDescription" name="MaterialIcons-Regular" family="Material Icons" pointSize="13"/>
+                            <color key="textColor" name="SecondaryText"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jGL-Xr-Bif">
+                            <rect key="frame" x="0.0" y="0.0" width="0.0" height="17"/>
+                            <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="11"/>
                             <color key="textColor" name="SecondaryText"/>
                             <nil key="highlightedColor"/>
                         </label>

--- a/sphinx/Scenes/Chat/View Controllers/New Chat View Controller/View Model & Data Source/MessageTableCellState/MessageLayoutState.swift
+++ b/sphinx/Scenes/Chat/View Controllers/New Chat View Controller/View Model & Data Source/MessageTableCellState/MessageLayoutState.swift
@@ -70,6 +70,7 @@ struct BubbleMessageLayoutState {
         var expirationTimestamp: String?
         var timestamp: String
         var messageDate: Date
+        var remoteTimezoneIdentifier: String?
         
         init(
             senderName: String?,
@@ -86,7 +87,8 @@ struct BubbleMessageLayoutState {
             showScheduleIcon: Bool,
             expirationTimestamp: String?,
             timestamp: String,
-            messageDate: Date
+            messageDate: Date,
+            remoteTimezoneIdentifier: String? = nil
         ) {
             self.senderName = senderName
             self.color = color
@@ -103,6 +105,7 @@ struct BubbleMessageLayoutState {
             self.expirationTimestamp = expirationTimestamp
             self.timestamp = timestamp
             self.messageDate = messageDate
+            self.remoteTimezoneIdentifier = remoteTimezoneIdentifier
         }
     }
     

--- a/sphinx/Scenes/Chat/View Controllers/New Chat View Controller/View Model & Data Source/MessageTableCellState/MessageTableCellState.swift
+++ b/sphinx/Scenes/Chat/View Controllers/New Chat View Controller/View Model & Data Source/MessageTableCellState/MessageTableCellState.swift
@@ -203,6 +203,7 @@ struct MessageTableCellState {
         let showBoltIcon = message.isConfirmedAsReceived()
         let showBoltGreyIcon = !message.isConfirmedAsReceived() && (message.isDirectPayment() || message.isPayment())
         let showFailedContainer = isSent && message.failed()
+        let timezoneIdentifier = chat.isGroup() ? (message.remoteTimezoneIdentifier ?? "") : ""
         
         var statusHeader = BubbleMessageLayoutState.StatusHeader(
             senderName: (chat.isConversation() ? nil : message.senderAlias),
@@ -219,7 +220,8 @@ struct MessageTableCellState {
             showScheduleIcon: !showBoltIcon && !showBoltGreyIcon && !showFailedContainer && isSent,
             expirationTimestamp: expirationTimestamp,
             timestamp: timestamp,
-            messageDate: message.date ?? Date()
+            messageDate: message.date ?? Date(),
+            remoteTimezoneIdentifier: timezoneIdentifier
         )
         
         return statusHeader


### PR DESCRIPTION
This PR adds the ability to display remote timezone information in the contact chat header and incoming message status header for tribes. The remoteTimezoneIdentifier value will be shown if it is set and not empty, with underscores replaced by spaces for better readability.

Changes:

Display remote timezone in the contact chat header.
Display remote timezone in the incoming message status header.
Format timezone identifiers by replacing underscores with spaces.