### PR TITLE
Timezone sharing ability - Restore timezone information during restore

### DIFF
--- a/sphinx/Crypter/SphinxOnionManager+ChatExtension.swift
+++ b/sphinx/Crypter/SphinxOnionManager+ChatExtension.swift
@@ -1134,7 +1134,9 @@ extension SphinxOnionManager {
             if chat.isGroup() {
                 newMessage.remoteTimezoneIdentifier = timezone
             } else {
-                chat.remoteTimezoneIdentifier = timezone
+                if !isV2Restore || chat.remoteTimezoneIdentifier == nil {
+                    chat.remoteTimezoneIdentifier = timezone
+                }
             }
         }
         


### PR DESCRIPTION
Store timezone information on chat.remoteTimezoneIdentifier if message contains timezone key inside metadata field. Apply this logic if it's a conversation message and chat.remoteTimezoneIdentifier is nil.