### PR TITLE
Generated with Hive: Fix replyUUID loss in message send and confirmation pipeline on iOS

### DIFF
--- a/sphinx/Crypter/SphinxOnionManager+ChatExtension.swift
+++ b/sphinx/Crypter/SphinxOnionManager+ChatExtension.swift
@@ -521,6 +521,15 @@ extension SphinxOnionManager {
 //        assignReceiverId(localMsg: localMsg)
 //        localMsg.managedObjectContext?.saveContext()
         
+        // Preserve replyUUID from inner content if the local message doesn't already have one
+        if localMsg.replyUUID == nil,
+           let msg = message.message,
+           let innerContent = MessageInnerContent(JSONString: msg),
+           let replyUuid = innerContent.replyUuid
+        {
+            localMsg.replyUUID = replyUuid
+        }
+        
         return localMsg
     }
     

--- a/sphinx/Scenes/Chat/View Controllers/New Chat View Controller/New Chat View Controller/NewChatViewController+BottomViewDelegateExtension.swift
+++ b/sphinx/Scenes/Chat/View Controllers/New Chat View Controller/New Chat View Controller/NewChatViewController+BottomViewDelegateExtension.swift
@@ -86,7 +86,7 @@ extension NewChatViewController : ChatMessageTextFieldViewDelegate {
             text: text,
             sendingAttachment: sendingAttachment,
             threadUUID: self.chatViewModel.replyingTo?.uuid,
-            replyUUID: self.threadUUID ?? self.chatViewModel.replyingTo?.replyUUID,
+            replyUUID: self.threadUUID ?? self.chatViewModel.replyingTo?.uuid,
             metaDataString: chat?.getMetaDataJsonStringValue(forceIncludeTimezone: self.chatViewModel.wasTimezoneNotSentRecently())
         )
         


### PR DESCRIPTION
Fix replyUUID loss in message send and confirmation pipeline on iOS