### PR TITLE
Generated with Hive: Add routeHint to AUTHORIZE postMsg payload for all authorization flows on iOS

### DIFF
--- a/sphinx/Scenes/WebAppsAndPodcasts/Helper/WebAppHelper.swift
+++ b/sphinx/Scenes/WebAppsAndPodcasts/Helper/WebAppHelper.swift
@@ -220,6 +220,9 @@ extension WebAppHelper : WKScriptMessageHandler {
             
             params["pubkey"] = pubKey as AnyObject
             
+            let routeHint = UserContact.getOwner()?.routeHint
+            params["routeHint"] = (routeHint ?? "") as AnyObject
+            
             saveValue(pubKey as AnyObject, for: "pubkey")
             
             if let signature = signature {


### PR DESCRIPTION
Add routeHint to AUTHORIZE postMsg payload for all authorization flows on iOS