### PR TITLE
Generated with Hive: Extend log retention to 72 hours on iOS

### DIFF
--- a/sphinx/Managers/Logging/AppLogger.swift
+++ b/sphinx/Managers/Logging/AppLogger.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - Constants
 
-private let kLogRetentionHours: Double = 24
+private let kLogRetentionHours: Double = 72
 
 // MARK: - LogLevel
 


### PR DESCRIPTION
Extends log retention from 24 hours to 72 hours on iOS.