### PR TITLE
Fix outbound tribe message timestamp to use relay clock on iOS

### DIFF
--- a/sphinx/Crypter/SphinxOnionManager+StructsAndHelpersExtension.swift
+++ b/sphinx/Crypter/SphinxOnionManager+StructsAndHelpersExtension.swift
@@ -205,9 +205,10 @@ struct GenericIncomingMessage: Mappable {
                 self.fullContactInfo = innerContent.fullContactInfo
             }
             
-            let isTribe = isTribeMessage
-            
-            if let timestamp = msg.timestamp, isTribe == false {
+            if msg.timestamp == nil {
+                print("⚠️ [GenericIncomingMessage] msg.timestamp is nil for \(isTribeMessage ? "tribe" : "DM") message — falling back to innerContent.date: \(String(describing: innerContent.date))")
+            }
+            if let timestamp = msg.timestamp {
                 self.timestamp = Int(timestamp)
             } else {
                 self.timestamp = innerContent.date


### PR DESCRIPTION
Generated with Hive: Fix outbound tribe message timestamp to use relay clock on iOS