### PR TITLE
Complete superseded background fetch handlers

### DIFF
--- a/sphinx/AppDelegate.swift
+++ b/sphinx/AppDelegate.swift
@@ -43,6 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var isActive = false
     private var pendingFetchWorkItem: DispatchWorkItem?
+    private var pendingFetchCompletionHandler: ((UIBackgroundFetchResult) -> Void)?
     
     public enum BuildType: Int {
         case Sideload
@@ -652,16 +653,19 @@ extension AppDelegate: @preconcurrency UNUserNotificationCenterDelegate {
             return
         }
         
-        // Cancel any pending debounced fetch
+        // Complete any superseded debounced fetch before replacing it.
         pendingFetchWorkItem?.cancel()
+        pendingFetchCompletionHandler?(.noData)
         print("[BGFetch] Notification received — debouncing 1.5s")
 
         let workItem = DispatchWorkItem { [weak self] in
             guard let self = self else { return }
             print("[BGFetch] Debounce elapsed — starting fetch")
+            self.pendingFetchCompletionHandler = nil
             self.som.beginBackgroundFetch(completionHandler: completionHandler)
         }
         pendingFetchWorkItem = workItem
+        pendingFetchCompletionHandler = completionHandler
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: workItem)
     }
 
@@ -774,4 +778,3 @@ extension AppDelegate : @preconcurrency PKPushRegistryDelegate {
         print("invalidated token")
     }
 }
-

--- a/sphinx/Crypter/SphinxOnionManager.swift
+++ b/sphinx/Crypter/SphinxOnionManager.swift
@@ -443,7 +443,7 @@ class SphinxOnionManager : NSObject, @unchecked Sendable {
         guard !backgroundFetchInProgress else {
             fetchLock.unlock()
             print("[BGFetch] Fetch already in progress — skipping duplicate")
-            backgroundFetchCompletionHandler = completionHandler
+            completionHandler(.noData)
             return
         }
         backgroundFetchInProgress = true
@@ -1053,4 +1053,3 @@ extension SphinxOnionManager {//Sign Up UI Related:
         return nil
     }
 }
-


### PR DESCRIPTION
## Summary
- complete a pending silent-push fetch handler with `noData` when a newer debounced push replaces it
- avoid overwriting the active background fetch completion handler when another fetch is already running
- keep duplicate background fetches from leaving iOS completion handlers unresolved

## Validation
- `git diff --check`
- `xcrun swiftc -parse sphinx/AppDelegate.swift sphinx/Crypter/SphinxOnionManager.swift`

Closes #162.