### PR TITLE
Generated with Hive: Accumulate all unconfirmed sent message tags in debounce to prevent status check loss

### DIFF
--- a/sphinx/Crypter/SphinxOnionManager+ChatExtension.swift
+++ b/sphinx/Crypter/SphinxOnionManager+ChatExtension.swift
@@ -2064,10 +2064,13 @@ extension SphinxOnionManager {
 //    }
     
     func scheduleStatusCheckForUnconfirmedSentMessage(tag: String) {
+        pendingStatusCheckTags.insert(tag)
         pendingSentStatusWorkItem?.cancel()
+        let tagsSnapshot = pendingStatusCheckTags
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
-            self.getMessagesStatusFor(tags: [tag])
+            self.getMessagesStatusFor(tags: Array(tagsSnapshot))
+            self.pendingStatusCheckTags.removeAll()
         }
         pendingSentStatusWorkItem = workItem
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 3.0, execute: workItem)

--- a/sphinx/Crypter/SphinxOnionManager.swift
+++ b/sphinx/Crypter/SphinxOnionManager.swift
@@ -119,6 +119,7 @@ class SphinxOnionManager : NSObject, @unchecked Sendable {
     var notificationsResultsController: NSFetchedResultsController<NotificationData>!
 
     var pendingSentStatusWorkItem: DispatchWorkItem?
+    var pendingStatusCheckTags: Set<String> = []
     
     let kHostedTorrentBaseURL = "https://files.bt2.bard.garden:21433"
     let kAllTorrentLookupBaseURL = "https://tome.bt2.bard.garden:21433"


### PR DESCRIPTION
Accumulate all unconfirmed sent message tags in debounce to prevent status check loss