### PR TITLE
Fix duplicate swipe action to use correct endpoint, complete POST body, and rewire downstream dependencies

### DIFF
--- a/sphinx/API/API+HiveExtension.swift
+++ b/sphinx/API/API+HiveExtension.swift
@@ -2582,16 +2582,26 @@ extension API {
         callback: @escaping HiveTaskCallback,
         errorCallback: @escaping EmptyCallback
     ) {
-        let urlString = "\(API.kHiveBaseUrl)/tasks"
+        guard let featureId = task.featureId,
+              let encodedFeatureId = featureId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
+            errorCallback(); return
+        }
+        let urlString = "\(API.kHiveBaseUrl)/features/\(encodedFeatureId)/tickets"
         var body: [String: Any] = [
-            "title": "Copy of \(task.title)",
-            "status": "TODO"
+            "title": task.title,
+            "status": "TODO",
+            "autoMerge": false,
+            "priority": task.priority
         ]
-        if let featureId = task.featureId { body["featureId"] = featureId }
-        if let repositoryId = task.repositoryId { body["repositoryId"] = repositoryId }
-        if let workflowId = task.workflowId { body["workflowId"] = workflowId }
-        if let workflowName = task.workflowName { body["workflowName"] = workflowName }
-        if let workflowRefId = task.workflowRefId { body["workflowRefId"] = workflowRefId }
+        if let v = task.description       { body["description"]       = v }
+        if let v = task.phaseId           { body["phaseId"]           = v }
+        if let v = task.repositoryId      { body["repositoryId"]      = v }
+        if !task.dependsOnTaskIds.isEmpty { body["dependsOnTaskIds"]  = task.dependsOnTaskIds }
+        if let v = task.workflowId        { body["workflowId"]        = v }
+        if let v = task.workflowName      { body["workflowName"]      = v }
+        if let v = task.workflowRefId     { body["workflowRefId"]     = v }
+        if let v = task.workflowTaskType  { body["workflowTaskType"]  = v }
+        if let v = task.workflowVersionId { body["workflowVersionId"] = v }
         guard let request = createRequest(urlString, bodyParams: body as NSDictionary, method: "POST", token: authToken) else {
             errorCallback(); return
         }
@@ -2613,6 +2623,64 @@ extension API {
                 errorCallback()
             }
         }
+    }
+
+    // MARK: - Update Task Dependencies (PATCH /api/tickets/{taskId})
+
+    private func updateTaskDependencies(
+        taskId: String,
+        dependsOnTaskIds: [String],
+        authToken: String,
+        callback: @escaping EmptyCallback,
+        errorCallback: @escaping EmptyCallback
+    ) {
+        guard let encoded = taskId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
+            errorCallback(); return
+        }
+        let urlString = "\(API.kHiveBaseUrl)/tickets/\(encoded)"
+        let body: [String: Any] = ["dependsOnTaskIds": dependsOnTaskIds]
+        guard let request = createRequest(urlString, bodyParams: body as NSDictionary, method: "PATCH", token: authToken) else {
+            errorCallback(); return
+        }
+        session()?.request(request).responseData { response in
+            if let statusCode = response.response?.statusCode, statusCode == 401 { errorCallback(); return }
+            switch response.result {
+            case .success: callback()
+            case .failure: errorCallback()
+            }
+        }
+    }
+
+    func updateTaskDependenciesWithAuth(
+        taskId: String,
+        dependsOnTaskIds: [String],
+        callback: @escaping EmptyCallback,
+        errorCallback: @escaping EmptyCallback
+    ) {
+        if let token: String = UserDefaults.Keys.hiveToken.get() {
+            updateTaskDependencies(taskId: taskId, dependsOnTaskIds: dependsOnTaskIds, authToken: token, callback: callback,
+                errorCallback: { [weak self] in
+                    self?.authenticateAndUpdateTaskDependencies(taskId: taskId, dependsOnTaskIds: dependsOnTaskIds,
+                        callback: callback, errorCallback: errorCallback)
+                })
+        } else {
+            authenticateAndUpdateTaskDependencies(taskId: taskId, dependsOnTaskIds: dependsOnTaskIds,
+                callback: callback, errorCallback: errorCallback)
+        }
+    }
+
+    private func authenticateAndUpdateTaskDependencies(
+        taskId: String,
+        dependsOnTaskIds: [String],
+        callback: @escaping EmptyCallback,
+        errorCallback: @escaping EmptyCallback
+    ) {
+        authenticateWithHive(callback: { [weak self] token in
+            guard let token = token else { errorCallback(); return }
+            UserDefaults.Keys.hiveToken.set(token)
+            self?.updateTaskDependencies(taskId: taskId, dependsOnTaskIds: dependsOnTaskIds, authToken: token,
+                callback: callback, errorCallback: errorCallback)
+        }, errorCallback: errorCallback)
     }
 
     func duplicateTaskWithAuth(

--- a/sphinx/Scenes/Dashboard/Workspaces/FeaturePlanViewController.swift
+++ b/sphinx/Scenes/Dashboard/Workspaces/FeaturePlanViewController.swift
@@ -1871,8 +1871,29 @@ extension FeaturePlanViewController: UITableViewDelegate, UITableViewDataSource 
             API.sharedInstance.duplicateTaskWithAuth(task: task, callback: { [weak self] newTask in
                 DispatchQueue.main.async {
                     guard let self, let newTask else { return }
+
+                    // Step 1 — optimistic local update
                     self.feature.looseTasks.append(newTask)
                     self.tasksTableView.reloadData()
+
+                    // Step 2 — rewire downstream dependencies in parallel
+                    let downstream = self.feature.allTasks.filter { $0.dependsOnTaskIds.contains(task.id) }
+                    guard !downstream.isEmpty else { return }
+
+                    let group = DispatchGroup()
+                    for downstreamTask in downstream {
+                        group.enter()
+                        let updatedDeps = downstreamTask.dependsOnTaskIds + [newTask.id]
+                        API.sharedInstance.updateTaskDependenciesWithAuth(
+                            taskId: downstreamTask.id,
+                            dependsOnTaskIds: updatedDeps,
+                            callback: { group.leave() },
+                            errorCallback: { group.leave() }
+                        )
+                    }
+                    group.notify(queue: .main) { [weak self] in
+                        self?.fetchFeatureDetail()
+                    }
                 }
             }, errorCallback: {})
             completionHandler(true)

--- a/sphinx/Scenes/Dashboard/Workspaces/HiveFeature.swift
+++ b/sphinx/Scenes/Dashboard/Workspaces/HiveFeature.swift
@@ -36,7 +36,11 @@ struct HivePhase {
         self.id = id
         self.name = json["name"].string ?? ""
         self.order = json["order"].int ?? 0
-        self.tasks = json["tasks"].arrayValue.compactMap { WorkspaceTask(json: $0) }
+        self.tasks = json["tasks"].arrayValue.compactMap { taskJson -> WorkspaceTask? in
+            guard var t = WorkspaceTask(json: taskJson) else { return nil }
+            t.phaseId = id
+            return t
+        }
     }
 }
 

--- a/sphinx/Scenes/Dashboard/Workspaces/WorkspaceTask.swift
+++ b/sphinx/Scenes/Dashboard/Workspaces/WorkspaceTask.swift
@@ -51,6 +51,9 @@ struct WorkspaceTask {
     let workflowId: Int?
     let workflowName: String?
     let workflowRefId: String?
+    var phaseId: String?           // injected post-init by HivePhase; nil for loose tasks
+    var workflowTaskType: String?  // parsed from JSON
+    var workflowVersionId: String? // parsed from JSON
 
     init?(json: JSON) {
         guard let id = json["id"].string,
@@ -96,5 +99,8 @@ struct WorkspaceTask {
         self.workflowId = json["workflowId"].int
         self.workflowName = json["workflowName"].string
         self.workflowRefId = json["workflowRefId"].string
+        self.workflowTaskType = json["workflowTaskType"].string
+        self.workflowVersionId = json["workflowVersionId"].string
+        self.phaseId = nil  // populated by HivePhase after init
     }
 }


### PR DESCRIPTION
Generated with Hive: Fix duplicate swipe action to use correct endpoint, complete POST body, and rewire downstream dependencies