### PR TITLE
Generated with Hive: Fix participant deduplication and empty-name refresh in iOS live call cells

### DIFF
--- a/sphinx/API/API+LiveKitExtension.swift
+++ b/sphinx/API/API+LiveKitExtension.swift
@@ -128,4 +128,39 @@ extension API {
             callback(true)
         }.resume()
     }
+
+    func getCallParticipants(
+        roomName: String,
+        callback: @escaping ([BubbleMessageLayoutState.CallParticipantInfo]) -> Void,
+        errorCallback: ((String) -> Void)? = nil
+    ) {
+        let url = "\(self.kVideoCallServer)/api/participants?roomName=\(roomName.urlEncode() ?? roomName)"
+        let request: URLRequest? = createRequest(url, bodyParams: nil, method: "GET")
+        guard let request = request else {
+            errorCallback?("Error creating request")
+            callback([])
+            return
+        }
+        sphinxRequest(request) { response in
+            switch response.result {
+            case .success(let data):
+                let json = JSON(data)
+                var participants: [BubbleMessageLayoutState.CallParticipantInfo] = []
+                for (_, item) in json {
+                    let name = item["nickname"].stringValue
+                    guard !name.isEmpty else { continue }
+                    participants.append(BubbleMessageLayoutState.CallParticipantInfo(
+                        identity: name,
+                        name: name,
+                        profilePictureUrl: item["avatarUrl"].string,
+                        isActive: true
+                    ))
+                }
+                callback(participants)
+            case .failure(let error):
+                errorCallback?(error.localizedDescription)
+                callback([])
+            }
+        }
+    }
 }

--- a/sphinx/Managers/CallParticipantsSocket/CallParticipantsSocketManager.swift
+++ b/sphinx/Managers/CallParticipantsSocket/CallParticipantsSocketManager.swift
@@ -134,7 +134,6 @@ class CallParticipantsSocketManager: NSObject, @unchecked Sendable {
     private func parseParticipant(from json: JSON) -> BubbleMessageLayoutState.CallParticipantInfo? {
         let nickname = json["nickname"].stringValue
         let identity = json["identity"].string
-        guard !nickname.isEmpty else { return nil }
         let avatarUrl = json["avatarUrl"].string
         return BubbleMessageLayoutState.CallParticipantInfo(
             identity: identity ?? nickname,

--- a/sphinx/Scenes/Chat/View Controllers/New Chat View Controller/View Model & Data Source/NewChatTableDataSource/NewChatTableDataSource+CellDelegateExtension.swift
+++ b/sphinx/Scenes/Chat/View Controllers/New Chat View Controller/View Model & Data Source/NewChatTableDataSource/NewChatTableDataSource+CellDelegateExtension.swift
@@ -576,9 +576,25 @@ extension NewChatTableDataSource {
 
     func participantJoined(roomName: String, participant: BubbleMessageLayoutState.CallParticipantInfo) {
         var current = callParticipantsStore[roomName] ?? []
+        // Dedup: skip if identity already tracked
+        guard !current.contains(where: { $0.identity == participant.identity }) else { return }
         current.append(participant)
         callParticipantsStore[roomName] = current
         reloadCells(forRoomName: roomName)
+        // LiveKit may not have resolved the display name yet — refresh after 2s
+        if participant.name.isEmpty {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+                self?.refreshParticipants(for: roomName)
+            }
+        }
+    }
+
+    private func refreshParticipants(for roomName: String) {
+        API.sharedInstance.getCallParticipants(roomName: roomName) { [weak self] fresh in
+            guard let self = self, !fresh.isEmpty else { return }
+            self.callParticipantsStore[roomName] = fresh
+            self.reloadCells(forRoomName: roomName)
+        }
     }
 
     func participantLeft(roomName: String, identity: String) {


### PR DESCRIPTION
Fix participant deduplication and empty-name refresh in iOS live call cells