### PR TITLE
Complete duplicate background fetch handlers

### DIFF
--- a/sphinx/Crypter/SphinxOnionManager.swift
+++ b/sphinx/Crypter/SphinxOnionManager.swift
@@ -467,7 +467,7 @@ class SphinxOnionManager : NSObject, @unchecked Sendable {
         guard !backgroundFetchInProgress else {
             fetchLock.unlock()
             print("[BGFetch] Fetch already in progress — skipping duplicate")
-            backgroundFetchCompletionHandler = completionHandler
+            completionHandler(.noData)
             return
         }
         backgroundFetchInProgress = true
@@ -1217,4 +1217,3 @@ extension SphinxOnionManager {//Sign Up UI Related:
         return nil
     }
 }
-


### PR DESCRIPTION
## Summary
- complete duplicate silent-push fetch handlers immediately with `.noData` when another background fetch is already running
- keep the active background fetch completion handler intact so the in-flight task can finish normally

## Validation
- `git diff --check`
- `xcrun swiftc -parse sphinx/Crypter/SphinxOnionManager.swift`

Closes #162.

BTC payout address: bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc