### PR TITLE
Fix unsafe interruption parsing crash and verify AirPods pause behavior during LiveKit calls on iOS

### DIFF
--- a/sphinx.xcodeproj/project.pbxproj
+++ b/sphinx.xcodeproj/project.pbxproj
@@ -728,6 +728,7 @@
 		C3D4E5F6A7B8C9D0E1F2A3B4 /* TaskProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6A7B8C9D0E1F2A3B4C5 /* TaskProgressBarView.swift */; };
 		C4D5E6F7A8B949C0D1E2F3A4 /* WorkspaceTaskTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E6F7A8B9CA4A01E2F3A4B5 /* WorkspaceTaskTableViewCellTests.swift */; };
 		CD3D4E5F6A7B8C9D0E1F2A3B /* ActiveCallBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4E5F6A7B8C9D0E1F2A3B4C /* ActiveCallBannerTests.swift */; };
+		PI001TEST0001000000000001 /* PodcastInterruptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PI001TEST0001000000000002 /* PodcastInterruptionTests.swift */; };
 		CE030A6B2B97C0860067F9F1 /* SphinxOnionManager+InvoicesExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE030A6A2B97C0860067F9F1 /* SphinxOnionManager+InvoicesExtension.swift */; };
 		CE07B83629DC92F900A02652 /* ItemDescriptionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE07B83429DC92F900A02652 /* ItemDescriptionTableViewCell.swift */; };
 		CE07B83729DC92F900A02652 /* ItemDescriptionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE07B83529DC92F900A02652 /* ItemDescriptionTableViewCell.xib */; };
@@ -2252,6 +2253,7 @@
 		D5E6F7A8B9CA4A01E2F3A4B5 /* WorkspaceTaskTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTaskTableViewCellTests.swift; sourceTree = "<group>"; };
 		DCA3CBE7EE324E7B8B07B278 /* ParticipantBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantBoxView.swift; sourceTree = "<group>"; };
 		DE4E5F6A7B8C9D0E1F2A3B4C /* ActiveCallBannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveCallBannerTests.swift; sourceTree = "<group>"; };
+		PI001TEST0001000000000002 /* PodcastInterruptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastInterruptionTests.swift; sourceTree = "<group>"; };
 		E2BA36BB571A4DCAA10EAFBB /* HiveFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiveFeatureMocks.swift; sourceTree = "<group>"; };
 		E36EF502A7E64ABA8FCF503E /* SetupAIAgentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupAIAgentViewController.swift; sourceTree = "<group>"; };
 		E5BD9804E22A4372A9E191D5 /* WorkflowStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowStatusView.swift; sourceTree = "<group>"; };
@@ -3823,6 +3825,7 @@
 				J0K1L2M3N4O5P6Q7R8S9T0U1 /* WorkspaceTasksViewControllerTests.swift */,
 				S4T5U6V7W8X9Y0Z1A2B3C4D5 /* PaginationControlViewTests.swift */,
 				DE4E5F6A7B8C9D0E1F2A3B4C /* ActiveCallBannerTests.swift */,
+				PI001TEST0001000000000002 /* PodcastInterruptionTests.swift */,
 				4779F179232AA0F300D35E81 /* sphinxOnionAddContactTests.swift */,
 				CE8161382B21124D00600C81 /* sphinxOnionPlaintextMessagesTests.swift */,
 				CE167B562B0BAF6A00A9238E /* sphinxOnionAccountCreateUnitTests.swift */,
@@ -6482,6 +6485,7 @@
 				I9J0K1L2M3N4O5P6Q7R8S9T0 /* WorkspaceTasksViewControllerTests.swift in Sources */,
 				R3S4T5U6V7W8X9Y0Z1A2B3C4 /* PaginationControlViewTests.swift in Sources */,
 				CD3D4E5F6A7B8C9D0E1F2A3B /* ActiveCallBannerTests.swift in Sources */,
+				PI001TEST0001000000000001 /* PodcastInterruptionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/sphinx/Helpers/PodcastPlayerController/PodcastPlayerController+AudioPlayer.swift
+++ b/sphinx/Helpers/PodcastPlayerController/PodcastPlayerController+AudioPlayer.swift
@@ -44,19 +44,24 @@ extension PodcastPlayerController {
             return
         }
         let info = notification.userInfo!
-        var intValue: UInt = 0
-        
-        (info[AVAudioSessionInterruptionTypeKey] as! NSValue).getValue(&intValue)
-        
-        if let interruptionType = AVAudioSession.InterruptionType(rawValue: intValue) {
-            switch interruptionType {
-            case .began:
-                if let podcastData = self.podcastData {
-                    self.pause(podcastData)
-                }
-            default:
-                break
+
+        // Safe optional cast — a force-cast here crashes on any absent or
+        // malformed AVAudioSessionInterruptionTypeKey value, regardless of call state.
+        guard let rawValue = (info[AVAudioSessionInterruptionTypeKey] as? NSNumber)?.uintValue,
+              let interruptionType = AVAudioSession.InterruptionType(rawValue: rawValue) else {
+            print("PodcastPlayerController: handleInterruption — missing or malformed interruption type key; ignoring")
+            return
+        }
+
+        print("PodcastPlayerController: handleInterruption — type=\(interruptionType.rawValue)")
+
+        switch interruptionType {
+        case .began:
+            if let podcastData = self.podcastData {
+                self.pause(podcastData)
             }
+        default:
+            break
         }
     }
 }

--- a/sphinx/Helpers/PodcastPlayerController/PodcastPlayerController+InfoCenter.swift
+++ b/sphinx/Helpers/PodcastPlayerController/PodcastPlayerController+InfoCenter.swift
@@ -176,6 +176,13 @@ extension PodcastPlayerController {
     }
     
     func shouldPlay() {
+        // During an active LiveKit call, remote play commands must be fully ignored
+        // (no-op) so that AirPods or other media controls cannot disrupt the call.
+        if VideoCallManager.sharedInstance.activeCall {
+            print("PodcastPlayerController: shouldPlay — suppressed while call is active")
+            return
+        }
+
         if isPlaying {
             return
         }
@@ -186,6 +193,13 @@ extension PodcastPlayerController {
     }
     
     func shouldPause() {
+        // During an active LiveKit call, remote pause commands must be fully ignored
+        // (no-op) so that AirPods or other media controls cannot disrupt the call.
+        if VideoCallManager.sharedInstance.activeCall {
+            print("PodcastPlayerController: shouldPause — suppressed while call is active")
+            return
+        }
+
         if !isPlaying {
             return
         }

--- a/sphinxTests/PodcastInterruptionTests.swift
+++ b/sphinxTests/PodcastInterruptionTests.swift
@@ -1,0 +1,210 @@
+//
+//  PodcastInterruptionTests.swift
+//  sphinxTests
+//
+//  Unit tests for:
+//    1. handleInterruption — safe optional casting (no force-cast crash)
+//    2. shouldPlay / shouldPause — no-op while VideoCallManager.activeCall is true
+//
+//  Copyright © 2024 sphinx. All rights reserved.
+//
+
+import XCTest
+import AVFoundation
+@testable import sphinx
+
+// MARK: - Helpers
+
+/// Posts an AVAudioSession interruption notification with the given userInfo and
+/// synchronously delivers it to the controller via handleInterruption(notification:).
+@MainActor
+private func postInterruption(
+    to controller: PodcastPlayerController,
+    userInfo: [AnyHashable: Any]?
+) {
+    let notification = NSNotification(
+        name: AVAudioSession.interruptionNotification,
+        object: AVAudioSession.sharedInstance(),
+        userInfo: userInfo
+    )
+    // Call the handler directly to stay on @MainActor without waiting for NotificationCenter dispatch.
+    controller.handleInterruption(notification: notification)
+}
+
+// MARK: - handleInterruption safety tests
+
+final class PodcastInterruptionSafetyTests: XCTestCase {
+
+    // MARK: Teardown helper — reset activeCall so tests don't bleed into each other.
+    override func tearDown() {
+        super.tearDown()
+        // Reset call state in case a test set it.
+        Task { @MainActor in
+            VideoCallManager.sharedInstance.activeCall = false
+        }
+    }
+
+    // MARK: Missing key — must not crash
+
+    /// handleInterruption must return safely when userInfo is nil (already guarded upstream,
+    /// but included for completeness).
+    @MainActor
+    func testHandleInterruption_nilUserInfo_doesNotCrash() {
+        let controller = PodcastPlayerController()
+        // Should not crash:
+        postInterruption(to: controller, userInfo: nil)
+    }
+
+    /// handleInterruption must return safely when AVAudioSessionInterruptionTypeKey is absent.
+    @MainActor
+    func testHandleInterruption_missingInterruptionKey_doesNotCrash() {
+        let controller = PodcastPlayerController()
+        postInterruption(to: controller, userInfo: [:])
+    }
+
+    /// handleInterruption must return safely when AVAudioSessionInterruptionTypeKey holds
+    /// an NSString (unexpected type, not NSNumber), not the expected NSNumber/UInt.
+    @MainActor
+    func testHandleInterruption_malformedStringValue_doesNotCrash() {
+        let controller = PodcastPlayerController()
+        let badInfo: [AnyHashable: Any] = [
+            AVAudioSessionInterruptionTypeKey: "not-a-number" as NSString
+        ]
+        postInterruption(to: controller, userInfo: badInfo)
+    }
+
+    /// handleInterruption must return safely when AVAudioSessionInterruptionTypeKey holds
+    /// a raw NSValue (the old force-cast target), which is neither NSNumber nor carries
+    /// the right rawValue.
+    @MainActor
+    func testHandleInterruption_malformedNSValue_doesNotCrash() {
+        let controller = PodcastPlayerController()
+        var bogus: UInt = 9999
+        let nsv = NSValue(bytes: &bogus, objCType: "I")
+        let badInfo: [AnyHashable: Any] = [AVAudioSessionInterruptionTypeKey: nsv]
+        postInterruption(to: controller, userInfo: badInfo)
+    }
+
+    /// handleInterruption must return safely when AVAudioSessionInterruptionTypeKey holds
+    /// a UInt rawValue that doesn't correspond to any AVAudioSession.InterruptionType case.
+    @MainActor
+    func testHandleInterruption_unknownRawValue_doesNotCrash() {
+        let controller = PodcastPlayerController()
+        let badInfo: [AnyHashable: Any] = [
+            AVAudioSessionInterruptionTypeKey: NSNumber(value: UInt(9999))
+        ]
+        postInterruption(to: controller, userInfo: badInfo)
+    }
+}
+
+// MARK: - handleInterruption regression: .began still pauses podcast
+
+final class PodcastInterruptionBehaviorTests: XCTestCase {
+
+    /// Tracks whether pause(podcastData:) was invoked.
+    private var pauseCallCount = 0
+
+    override func setUp() {
+        super.setUp()
+        pauseCallCount = 0
+        Task { @MainActor in
+            VideoCallManager.sharedInstance.activeCall = false
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        Task { @MainActor in
+            VideoCallManager.sharedInstance.activeCall = false
+        }
+    }
+
+    /// A valid .began interruption must cause the podcast to pause.
+    /// We verify indirectly: AVPlayer starts nil, so pause() is a no-op on the player
+    /// itself — but we can confirm at minimum that no crash occurs and the code path
+    /// runs through the .began branch without error.
+    @MainActor
+    func testHandleInterruption_validBegan_doesNotCrash() {
+        let controller = PodcastPlayerController()
+        let validInfo: [AnyHashable: Any] = [
+            AVAudioSessionInterruptionTypeKey: NSNumber(value: AVAudioSession.InterruptionType.began.rawValue)
+        ]
+        // Should not crash — verifies the safe-cast path produces the correct InterruptionType
+        // and attempts to pause (harmless when player is nil).
+        postInterruption(to: controller, userInfo: validInfo)
+    }
+
+    /// A valid .ended interruption must not crash and must not try to pause.
+    @MainActor
+    func testHandleInterruption_validEnded_doesNotCrash() {
+        let controller = PodcastPlayerController()
+        let validInfo: [AnyHashable: Any] = [
+            AVAudioSessionInterruptionTypeKey: NSNumber(value: AVAudioSession.InterruptionType.ended.rawValue)
+        ]
+        postInterruption(to: controller, userInfo: validInfo)
+    }
+}
+
+// MARK: - shouldPlay / shouldPause no-op while activeCall is true
+
+final class PodcastRemoteCommandCallGateTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        Task { @MainActor in
+            VideoCallManager.sharedInstance.activeCall = false
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        Task { @MainActor in
+            VideoCallManager.sharedInstance.activeCall = false
+        }
+    }
+
+    /// shouldPlay() must return early (no-op) when an active call is in progress.
+    /// We verify by confirming that no crash occurs and the method returns without
+    /// touching podcastData (controller has no podcast loaded — if shouldPlay ever
+    /// reached the play(podcastData:) call it would return from the isPlaying guard
+    /// or the nil guard anyway, but the activeCall check fires first).
+    @MainActor
+    func testShouldPlay_suppressedDuringActiveCall() {
+        VideoCallManager.sharedInstance.activeCall = true
+        let controller = PodcastPlayerController()
+        // Must not crash, must not attempt play:
+        controller.shouldPlay()
+        // Reset
+        VideoCallManager.sharedInstance.activeCall = false
+    }
+
+    /// shouldPause() must return early (no-op) when an active call is in progress.
+    @MainActor
+    func testShouldPause_suppressedDuringActiveCall() {
+        VideoCallManager.sharedInstance.activeCall = true
+        let controller = PodcastPlayerController()
+        // Must not crash, must not attempt pause:
+        controller.shouldPause()
+        // Reset
+        VideoCallManager.sharedInstance.activeCall = false
+    }
+
+    /// shouldPlay() must proceed normally (reach isPlaying check) when no call is active.
+    /// With no player loaded, isPlaying is false so play() is attempted (harmlessly).
+    @MainActor
+    func testShouldPlay_allowedWhenNoActiveCall() {
+        VideoCallManager.sharedInstance.activeCall = false
+        let controller = PodcastPlayerController()
+        // Should reach the isPlaying/podcastData branches without crashing:
+        controller.shouldPlay()
+    }
+
+    /// shouldPause() must proceed normally when no call is active.
+    /// With no player loaded, isPlaying is false so the early-return guard fires before pause().
+    @MainActor
+    func testShouldPause_allowedWhenNoActiveCall() {
+        VideoCallManager.sharedInstance.activeCall = false
+        let controller = PodcastPlayerController()
+        controller.shouldPause()
+    }
+}


### PR DESCRIPTION
Generated with Hive: Fix unsafe interruption parsing crash and verify AirPods pause behavior during LiveKit calls on iOS