### PR TITLE
Revert tribe timestamp regression in GenericIncomingMessage and add unit tests

### DIFF
--- a/sphinx.xcodeproj/project.pbxproj
+++ b/sphinx.xcodeproj/project.pbxproj
@@ -973,6 +973,7 @@
 		K1L2M3N4O5P6Q7R8S9T0U1V2 /* CreateFeatureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = L2M3N4O5P6Q7R8S9T0U1V2W3 /* CreateFeatureViewController.swift */; };
 		LC001TEST0001000000000001 /* LiveCallBannerFoundationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LC001TEST0001000000000002 /* LiveCallBannerFoundationTests.swift */; };
 		M3N4O5P6Q7R8S9T0U1V2W3X4 /* HiveProcessingBubbleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = N4O5P6Q7R8S9T0U1V2W3X4Y5 /* HiveProcessingBubbleCell.swift */; };
+		GIM001TEST0001000000000002 /* GenericIncomingMessageTimestampTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = GIM001TEST0001000000000001 /* GenericIncomingMessageTimestampTests.swift */; };
 		MC001TEST0001000000000002 /* MediaCacheUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MC001TEST0001000000000001 /* MediaCacheUpdateTests.swift */; };
 		MC01AA11BB22CC33DD44EE02 /* MarkdownContentSplitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = MC01AA11BB22CC33DD44EE01 /* MarkdownContentSplitter.swift */; };
 		MT01AA11BB22CC33DD44EE02 /* MarkdownTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MT01AA11BB22CC33DD44EE01 /* MarkdownTableView.swift */; };
@@ -2391,6 +2392,7 @@
 		J0K1L2M3N4O5P6Q7R8S9T0U1 /* WorkspaceTasksViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTasksViewControllerTests.swift; sourceTree = "<group>"; };
 		L2M3N4O5P6Q7R8S9T0U1V2W3 /* CreateFeatureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFeatureViewController.swift; sourceTree = "<group>"; };
 		LC001TEST0001000000000002 /* LiveCallBannerFoundationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveCallBannerFoundationTests.swift; sourceTree = "<group>"; };
+		GIM001TEST0001000000000001 /* GenericIncomingMessageTimestampTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericIncomingMessageTimestampTests.swift; sourceTree = "<group>"; };
 		MC001TEST0001000000000001 /* MediaCacheUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaCacheUpdateTests.swift; sourceTree = "<group>"; };
 		MC01AA11BB22CC33DD44EE01 /* MarkdownContentSplitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownContentSplitter.swift; sourceTree = "<group>"; };
 		MT01AA11BB22CC33DD44EE01 /* MarkdownTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTableView.swift; sourceTree = "<group>"; };

--- a/sphinx/Crypter/SphinxOnionManager+ChatExtension.swift
+++ b/sphinx/Crypter/SphinxOnionManager+ChatExtension.swift
@@ -652,6 +652,12 @@ extension SphinxOnionManager {
 
                     let tribe: Chat? = senderInfo?.pubkey.flatMap { tribesMap[$0] }
 
+                    // `tribe != nil` is the authoritative source of truth for the timestamp gate
+                    // in GenericIncomingMessage.init — tribe messages use innerContent.date
+                    // (sender-embedded), DMs use msg.timestamp (relay clock).
+                    // Do NOT substitute ContactServerResponse.isTribeMessage() (checks for a
+                    // `role` field) or the free function isTribeMessage(senderPubkey:) (checks
+                    // Chat existence via ownerPubkey) — both give different answers here.
                     var genericIncomingMessage = GenericIncomingMessage(
                         msg: $0,
                         csr: senderInfo,

--- a/sphinx/Crypter/SphinxOnionManager+StructsAndHelpersExtension.swift
+++ b/sphinx/Crypter/SphinxOnionManager+StructsAndHelpersExtension.swift
@@ -205,12 +205,13 @@ struct GenericIncomingMessage: Mappable {
                 self.fullContactInfo = innerContent.fullContactInfo
             }
             
-            if let timestamp = msg.timestamp {
+            if let timestamp = msg.timestamp, isTribeMessage == false {
                 self.timestamp = Int(timestamp)
             } else {
                 self.timestamp = innerContent.date
-                
-                print("⚠️ [GenericIncomingMessage] msg.timestamp is nil for \(isTribeMessage ? "tribe" : "DM") message — falling back to innerContent.date: \(String(describing: innerContent.date))")
+                if !isTribeMessage && msg.timestamp == nil {
+                    print("⚠️ [GenericIncomingMessage] msg.timestamp is nil for DM message — falling back to innerContent.date: \(String(describing: innerContent.date))")
+                }
             }
             
             if let metadataString = innerContent.metadata,

--- a/sphinxTests/GenericIncomingMessageTimestampTests.swift
+++ b/sphinxTests/GenericIncomingMessageTimestampTests.swift
@@ -1,0 +1,139 @@
+//
+//  GenericIncomingMessageTimestampTests.swift
+//  sphinxTests
+//
+//  Tests the tribe/DM timestamp gate in GenericIncomingMessage.init.
+//  PR #591 regressed this once by removing the isTribe guard; these four
+//  cases lock the correct branch behaviour to prevent a repeat.
+//
+
+import XCTest
+@testable import sphinx
+
+class GenericIncomingMessageTimestampTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Builds a minimal Msg with the given relay timestamp (nil == absent).
+    private func makeMsg(timestamp: UInt64?) -> Msg {
+        return Msg(
+            message: nil,
+            type: UInt8(TransactionMessage.TransactionMessageType.message.rawValue),
+            uuid: nil,
+            tag: nil,
+            index: nil,
+            sender: nil,
+            msat: nil,
+            timestamp: timestamp,
+            sentTo: nil,
+            fromMe: nil,
+            paymentHash: nil,
+            error: nil
+        )
+    }
+
+    /// Builds a minimal MessageInnerContent with the given sender-embedded date.
+    private func makeInnerContent(date: Int) -> MessageInnerContent {
+        var ic = MessageInnerContent(JSONString: "{}")!
+        ic.date = date
+        return ic
+    }
+
+    // MARK: - Tribe message, msg.timestamp present
+    // Tribe messages must always use innerContent.date regardless of relay timestamp.
+
+    func testTribeMessage_withRelayTimestamp_usesInnerContentDate() {
+        let relayTimestamp: UInt64 = 9_999_999
+        let innerDate = 1_000_000
+
+        let msg = makeMsg(timestamp: relayTimestamp)
+        let inner = makeInnerContent(date: innerDate)
+
+        let sut = GenericIncomingMessage(
+            msg: msg,
+            csr: nil,
+            innerContent: inner,
+            isTribeMessage: true
+        )
+
+        XCTAssertEqual(
+            sut?.timestamp, innerDate,
+            "Tribe message must use innerContent.date, not the relay timestamp"
+        )
+        XCTAssertNotEqual(
+            sut?.timestamp, Int(relayTimestamp),
+            "Tribe message must NOT use msg.timestamp"
+        )
+    }
+
+    // MARK: - Tribe message, msg.timestamp nil
+    // Must fall back to innerContent.date without crashing or logging.
+
+    func testTribeMessage_nilRelayTimestamp_usesInnerContentDate() {
+        let innerDate = 1_234_567
+
+        let msg = makeMsg(timestamp: nil)
+        let inner = makeInnerContent(date: innerDate)
+
+        let sut = GenericIncomingMessage(
+            msg: msg,
+            csr: nil,
+            innerContent: inner,
+            isTribeMessage: true
+        )
+
+        XCTAssertEqual(
+            sut?.timestamp, innerDate,
+            "Tribe message with nil relay timestamp must use innerContent.date"
+        )
+    }
+
+    // MARK: - DM, msg.timestamp present
+    // DMs prefer the relay timestamp when it is present.
+
+    func testDMMessage_withRelayTimestamp_usesRelayTimestamp() {
+        let relayTimestamp: UInt64 = 8_888_888
+        let innerDate = 1_111_111
+
+        let msg = makeMsg(timestamp: relayTimestamp)
+        let inner = makeInnerContent(date: innerDate)
+
+        let sut = GenericIncomingMessage(
+            msg: msg,
+            csr: nil,
+            innerContent: inner,
+            isTribeMessage: false
+        )
+
+        XCTAssertEqual(
+            sut?.timestamp, Int(relayTimestamp),
+            "DM message with relay timestamp must use msg.timestamp"
+        )
+        XCTAssertNotEqual(
+            sut?.timestamp, innerDate,
+            "DM message with relay timestamp must NOT fall back to innerContent.date"
+        )
+    }
+
+    // MARK: - DM, msg.timestamp nil
+    // DMs fall back to innerContent.date when relay timestamp is absent.
+
+    func testDMMessage_nilRelayTimestamp_usesInnerContentDate() {
+        let innerDate = 2_222_222
+
+        let msg = makeMsg(timestamp: nil)
+        let inner = makeInnerContent(date: innerDate)
+
+        let sut = GenericIncomingMessage(
+            msg: msg,
+            csr: nil,
+            innerContent: inner,
+            isTribeMessage: false
+        )
+
+        XCTAssertEqual(
+            sut?.timestamp, innerDate,
+            "DM message with nil relay timestamp must fall back to innerContent.date"
+        )
+    }
+}


### PR DESCRIPTION
Generated with Hive: Revert tribe timestamp regression in GenericIncomingMessage and add unit tests